### PR TITLE
[fix] ignore line begining with a #

### DIFF
--- a/src/commit.js
+++ b/src/commit.js
@@ -1,6 +1,6 @@
 /* eslint no-console: 'off' */
 import argv from 'minimist-argv';
-import { readFileSync, unlinkSync } from 'fs';
+import { unlinkSync } from 'fs';
 import { execSync, spawnSync } from 'child_process';
 import prepareCommitMessage from './prepare-commit-msg';
 import notification from './notifications';
@@ -34,14 +34,9 @@ export default function () {
     .then(() => {
       execSync('$EDITOR \\#temp_commit', { stdio: 'inherit' });
 
-      const commitMsg = readFileSync(argv.path);
-      if (!commitMsg) {
-        throw new Error('The commit message is empty');
-      }
-
       spawnSync(
         'git',
-        ['commit', '--cleanup=strip', `-m${commitMsg}`].concat(process.argv.slice(2)),
+        ['commit', `-F${argv.path}`].concat(process.argv.slice(2)),
         { stdio: 'inherit' },
       );
     })

--- a/src/commit.js
+++ b/src/commit.js
@@ -41,7 +41,7 @@ export default function () {
 
       spawnSync(
         'git',
-        ['commit'].concat(process.argv.slice(2)).concat(`-m${commitMsg}`),
+        ['commit', '--cleanup=strip', `-m${commitMsg}`].concat(process.argv.slice(2)),
         { stdio: 'inherit' },
       );
     })


### PR DESCRIPTION
### Why this changes ?

the lines begining by `#` was not ignored when committing...
### How it addresses the issue ?

by adding the `--cleanup=strip` options to the commit command it now ignore the lines begining with `#`

Closes: #6
